### PR TITLE
Xb 40 whitelist script

### DIFF
--- a/src/utils/whitelistable.ts
+++ b/src/utils/whitelistable.ts
@@ -968,6 +968,7 @@ export const isWhitelistable = async (
   }
 
   const doubleSlashCommentsRegex = /\/\/.*?(\\n)/g;
+  const doubleSlashCommentsRegexForNextLine = /\/\/.*$/gm;
   const nextLineRegex = /\n/g;
   const nextLineWithDoubleSlashRegex = /\\n/g;
   const tabRgex = /\r/g;
@@ -986,6 +987,7 @@ export const isWhitelistable = async (
   }
   sourceCode = sourceCode
     .replace(doubleSlashCommentsRegex, '')
+    .replace(doubleSlashCommentsRegexForNextLine, '')
     .replace(blockCommentsRegex, '')
     .replace(nextLineRegex, '')
     .replace(escapeSlashRegex, '"')

--- a/src/utils/whitelistable.ts
+++ b/src/utils/whitelistable.ts
@@ -976,6 +976,7 @@ export const isWhitelistable = async (
   const escapeSlashRegex = /\\"/g;
   const blockCommentsRegex = /\/\*[\s\S]*?\*\//g;
   const functionNamesRegex = /(function|constructor)\s+(\w+)\s*\(/;
+  const requireErrorString = /(\brequire[(][^,]*,[(...)]*)[^)]+(\))/g;
   const spaceRegex = /\s/g;
 
   let sourceCode = data.data.result[0].SourceCode;
@@ -990,6 +991,7 @@ export const isWhitelistable = async (
     .replace(doubleSlashCommentsRegexForNextLine, '')
     .replace(blockCommentsRegex, '')
     .replace(nextLineRegex, '')
+    .replace(requireErrorString, '$1""$2')
     .replace(escapeSlashRegex, '"')
     .replace(tabRgex, '')
     .replace(tabRgex_, '')


### PR DESCRIPTION
Feature

- Old behavious: regex was not working for singleline comments in some cases, and unwanted error strings inside require
- New behaviour: script is removing all single line comments and error strings inside require.

Ticker: [XB-40](https://xp-network.atlassian.net/jira/core/projects/XB/board?selectedIssue=XB-40)